### PR TITLE
Fix bugs for multi channel usecases

### DIFF
--- a/configs/multi_input_multi_infer.yaml
+++ b/configs/multi_input_multi_infer.yaml
@@ -22,7 +22,7 @@ models:
         model_path: /opt/model_zoo/ONR-OD-8020-ssd-lite-mobv2-mmdet-coco-512x512
         viz_threshold: 0.6
     model3:
-        model_path: /opt/model_zoo/ONR-SS-8610-deeplabv3lite-mobv2-ade20k32-512x512
+        model_path: /opt/model_zoo/TFL-SS-2580-deeplabv3_mobv2-ade20k32-mlperf-512x512
         alpha: 0.4
 outputs:
     output0:

--- a/configs/multi_input_single_infer.yaml
+++ b/configs/multi_input_single_infer.yaml
@@ -32,7 +32,7 @@ models:
         model_path: /opt/model_zoo/ONR-OD-8020-ssd-lite-mobv2-mmdet-coco-512x512
         viz_threshold: 0.6
     model3:
-        model_path: /opt/model_zoo/ONR-SS-8610-deeplabv3lite-mobv2-ade20k32-512x512
+        model_path: /opt/model_zoo/TFL-SS-2580-deeplabv3_mobv2-ade20k32-mlperf-512x512
         alpha: 0.4
 outputs:
     output0:

--- a/configs/semantic_segmentation.yaml
+++ b/configs/semantic_segmentation.yaml
@@ -20,9 +20,6 @@ models:
     model0:
         model_path: /opt/model_zoo/TFL-SS-2580-deeplabv3_mobv2-ade20k32-mlperf-512x512
         alpha: 0.4
-    model1:
-        model_path: /opt/model_zoo/ONR-SS-8610-deeplabv3lite-mobv2-ade20k32-512x512
-        alpha: 0.4
 outputs:
     output0:
         sink: display
@@ -38,4 +35,4 @@ outputs:
         height: 1080
 
 flows:
-    flow0: [input0,model1,output0,[320,150,1280,720]]
+    flow0: [input0,model0,output0,[320,150,1280,720]]

--- a/configs/single_input_multi_infer.yaml
+++ b/configs/single_input_multi_infer.yaml
@@ -27,7 +27,7 @@ models:
         model_path: /opt/model_zoo/ONR-OD-8020-ssd-lite-mobv2-mmdet-coco-512x512
         viz_threshold: 0.6
     model3:
-        model_path: /opt/model_zoo/ONR-SS-8610-deeplabv3lite-mobv2-ade20k32-512x512
+        model_path: /opt/model_zoo/TFL-SS-2580-deeplabv3_mobv2-ade20k32-mlperf-512x512
         alpha: 0.4
 outputs:
     output0:


### PR DESCRIPTION
While fixing klockwork issues, some bugs
were introduced in application. This commit
resolves those errors.
-> Issue with multi input multi infer pipeline:
   New msc, pre-proc, tidl, post-proc objects were not getting
   created for multiple flows and their subflows.
   Solution: create unique object for MSC, pre-proc, tidl,
   post-proc for every flow and every subflow

-> Issue with  multi input(camera) single infer pipeline:
   MSC, tidl, pre-proc, post-proc modules were getting created
   for every flow which should not be the case for this usecase.
   Solution: Dont create multiple MSC, pre-proc, tidl, post-proc
   for every flow because we are using replicate node feature in
   case of multiple camera inputs

-> Issue with single input multi infer pipeline:
   The camera to msc mapping got messed up while fixing klockwork
   issues.
   Solution: Use proper index for camera to msc mapping

-> Also, make the default segmentation model as TFL-SS in config files (as
   ONR-SS model not working).