### PR TITLE
Fix ONR-SS seg fault issue

### DIFF
--- a/common/src/edgeai_post_proc.cpp
+++ b/common/src/edgeai_post_proc.cpp
@@ -277,13 +277,13 @@ int32_t postProc::getConfig(const string        &modelBasePath,
             }
 
             dlPostProcObj.params.ss_prms.ioBufDesc = ioBufDesc;
-            dlPostProcObj.params.ss_prms.inDataWidth = ioBufDesc->inWidth[0]   +
-                                                       ioBufDesc->inPadL[0]    +
-                                                       ioBufDesc->inPadR[0];
+            dlPostProcObj.params.ss_prms.inDataWidth = ioBufDesc->outWidth[0]   +
+                                                       ioBufDesc->outPadL[0]    +
+                                                       ioBufDesc->outPadR[0];
 
-            dlPostProcObj.params.ss_prms.inDataHeight = ioBufDesc->inHeight[0] +
-                                                        ioBufDesc->inPadT[0]   +
-                                                        ioBufDesc->inPadB[0];
+            dlPostProcObj.params.ss_prms.inDataHeight = ioBufDesc->outHeight[0] +
+                                                        ioBufDesc->outPadT[0]   +
+                                                        ioBufDesc->outPadB[0];
             dlPostProcObj.params.ss_prms.alpha = 0.4;
             dlPostProcObj.params.ss_prms.YUVColorMap = mYUVColorMap;
             dlPostProcObj.params.ss_prms.MaxColorClass = mMaxColorClass;

--- a/configs/semantic_segmentation.yaml
+++ b/configs/semantic_segmentation.yaml
@@ -7,7 +7,7 @@ inputs:
         height: 1080
         camera-id: 0
     input1:
-        source: /opt/edgeai-test-data/raw_images/0001.nv12
+        source: /opt/edgeai-test-data/raw_images/tiovx_apps/0001.nv12
         width: 1280
         height: 720
         loop: True
@@ -19,6 +19,12 @@ inputs:
 models:
     model0:
         model_path: /opt/model_zoo/TFL-SS-2580-deeplabv3_mobv2-ade20k32-mlperf-512x512
+        alpha: 0.4
+    model1:
+        model_path: /opt/model_zoo/ONR-SS-8610-deeplabv3lite-mobv2-ade20k32-512x512
+        alpha: 0.4
+    model2:
+        model_path: /opt/model_zoo/ONR-SS-8818-deeplabv3lite-mobv2-qat-robokit-768x432
         alpha: 0.4
 outputs:
     output0:


### PR DESCRIPTION
inDataWidth of post proc kernel should be equal to width of output tidl tensor. Previously it was equal to width of input tidl tensor.
In model ONR-SS-8610-deeplabv3lite-mobv2-ade20k32-512x512 the input and output tensor dimensions are not same, as compared to other segmentation models where input and output tensor dimensions are same, thereby exposing this bug in application