### PR TITLE
apps: Increase buffer pool size for rtos capture to 8

### DIFF
--- a/apps/src/app.c
+++ b/apps/src/app.c
@@ -961,10 +961,11 @@ int32_t run_app(FlowInfo flow_infos[], uint32_t num_flows)
         /* Why RTOS Cam needs two */
         if (RTOS_CAM == input_blocks[i].input_info->source)
         {
-            inbuf = tiovx_modules_dequeue_buf(in_buf_pool);
-            tiovx_modules_release_buf(inbuf);
-            inbuf = tiovx_modules_dequeue_buf(in_buf_pool);
-            tiovx_modules_release_buf(inbuf);
+            for(j = 0; j < in_buf_pool->bufq_depth - 2; j++)
+            {
+                inbuf = tiovx_modules_dequeue_buf(in_buf_pool);
+                tiovx_modules_release_buf(inbuf);
+            }
         }
         else if (LINUX_CAM == input_blocks[i].input_info->source)
         {

--- a/apps/src/input_block.c
+++ b/apps/src/input_block.c
@@ -193,7 +193,7 @@ int32_t create_input_block(GraphObj *graph, InputBlock *input_block)
                                               TIOVX_TEE,
                                               (void *)&tee_cfg);
 
-            tee_node->srcs[0].bufq_depth = 4; /* This must be greater than 3 */
+            tee_node->srcs[0].bufq_depth = 8; /* This must be greater than 3 */
 
             input_pad = &tee_node->srcs[0];
             output_pad = &tee_node->srcs[1];


### PR DESCRIPTION
Keeping the buffer pool size lower results in lower fps with multiple channel. This needs more analysis.