### PR TITLE
[AM62A]: Fixed build issues during make edgeai for AM62A on Linux and QNX

### DIFF
--- a/modules/core/include/tiovx_modules_cbs.h
+++ b/modules/core/include/tiovx_modules_cbs.h
@@ -83,6 +83,8 @@
 
 #if !defined(SOC_AM62A)
 #include "tiovx_display_module.h"
+#endif
+#if (defined(SOC_AM62A) && defined(TARGET_OS_QNX))
 #include "tiovx_capture_module.h"
 #include "tiovx_aewb_module.h"
 #endif
@@ -121,6 +123,8 @@ typedef enum {
     TIOVX_LUT,
 #if !defined(SOC_AM62A)
     TIOVX_DISPLAY,
+#endif
+#if (defined(SOC_AM62A) && defined(TARGET_OS_QNX))
     TIOVX_CAPTURE,
     TIOVX_AEWB,
 #endif

--- a/modules/core/src/tiovx_modules_cbs.c
+++ b/modules/core/src/tiovx_modules_cbs.c
@@ -216,6 +216,8 @@ NodeCbs gNodeCbs[TIOVX_MODULES_NUM_MODULES] =
         .get_cfg_size = tiovx_display_get_cfg_size,
         .get_priv_size = tiovx_display_get_priv_size
     },
+   #endif
+   #if (defined(SOC_AM62A) && defined(TARGET_OS_QNX))
     {
         .init_node = tiovx_capture_init_node,
         .create_node = tiovx_capture_create_node,


### PR DESCRIPTION
- Added capture and aewb nodes used by AM62A QNX in demo examples
- These nodes when used in AM62A Linux caused build issues during make edgeai