### PR TITLE
tiovx_modules: Fix mutex unlock issue in dequeue/acquire paths

### DIFF
--- a/modules/core/src/tiovx_modules.c
+++ b/modules/core/src/tiovx_modules.c
@@ -151,6 +151,7 @@ Buf* tiovx_modules_acquire_buf(BufPool *buf_pool)
 
     if (!buf_pool->free_count) {
         TIOVX_MODULE_ERROR("No free buffer\n");
+        UNLOCK(buf_pool);
         return NULL;
     }
 
@@ -881,6 +882,7 @@ vx_status tiovx_modules_enqueue_buf(Buf *buf)
     if (buf_pool->enqueue_tail ==
                     (buf_pool->enqueue_head + 1) % (buf_pool->bufq_depth + 1)) {
         TIOVX_MODULE_ERROR("Queue Full\n");
+        UNLOCK(buf_pool);
         return status;
     }
 
@@ -923,6 +925,7 @@ Buf* tiovx_modules_dequeue_buf(BufPool *buf_pool)
 
     if (buf_pool->enqueue_tail == buf_pool->enqueue_head) {
         TIOVX_MODULE_ERROR("Queue Empty\n");
+        UNLOCK(buf_pool);
         return NULL;
     }
 


### PR DESCRIPTION
* Add mutex unlock calls in error paths where the function was returning without unlocking the buffer pool mutex. Following functions were handled,

   - tiovx_modules_dequeue_buf: Added UNLOCK before return when queue is empty
   - tiovx_modules_acquire_buf: Added UNLOCK before return when no free buffer
   - tiovx_modules_enqueue_buf: Added UNLOCK before return when queue is full

* These conditions should not occur in properly implemented applications, but they represent potentially dangerous code paths that could leave a buffer pool in a locked state, as reported by customers on E2E [0]

* Fixes SITSW-7170

[0] - https://e2e.ti.com/support/processors-group/processors/f/processors-forum/1451673/am62a7-tiovx_modules_dequeue_buf-acquire-mutex-lock-unlock-issue